### PR TITLE
Fanil2

### DIFF
--- a/src/middlewares/aiRateLimiter.ts
+++ b/src/middlewares/aiRateLimiter.ts
@@ -5,7 +5,7 @@ import { Request, Response, NextFunction } from 'express';
 import { AppError } from '@/types';
 import AuthenticatedRequest from '@/types/authenticatedRequest';
 
-const DAILY_LIMIT: number = 10; 
+const DAILY_LIMIT: number = 10;
 
 const aiRateLimiter: RateLimitRequestHandler = rateLimit(
 
@@ -14,6 +14,10 @@ const aiRateLimiter: RateLimitRequestHandler = rateLimit(
 		windowMs: 24 * 60 * 60 * 1000,
 
 		limit: DAILY_LIMIT,
+
+		skip: () => false,
+
+		skipFailedRequests: true,	
 
 		keyGenerator: (req: Request, _res: Response): string => {
 
@@ -24,8 +28,6 @@ const aiRateLimiter: RateLimitRequestHandler = rateLimit(
 		},
 
 		store: new RedisStore({ sendCommand: (...args: string[]) => redisClient.sendCommand(args) }),
-
-		skip: () => true,
 
 		handler: (_req: Request, _res: Response, next: NextFunction) => {
 

--- a/src/middlewares/aiUsageCounter.ts
+++ b/src/middlewares/aiUsageCounter.ts
@@ -10,11 +10,15 @@ const incrementAiLimitOnSuccess = (req: AuthenticatedRequest, res: Response, nex
 
     res.on('finish', async (): Promise<void> => {
 
-        if (res.statusCode >= 200 && res.statusCode <= 300) {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
             
             try {
                 
-                typedAiRateLimiter.store.increment(typedAiRateLimiter.keyGenerator(req, res));
+                if (typedAiRateLimiter.store && typedAiRateLimiter.keyGenerator) {
+
+                    typedAiRateLimiter.store.increment(typedAiRateLimiter.keyGenerator(req, res));
+
+                }
 
             } catch (err: unknown) {
 
@@ -25,7 +29,7 @@ const incrementAiLimitOnSuccess = (req: AuthenticatedRequest, res: Response, nex
                     stack: err instanceof Error ? err.stack : undefined,
                     url: req.originalUrl,
                     method: req.method,
-                    status: res.statusCode
+                    status: res.statusCode,
 
                 });
                 

--- a/src/middlewares/aiUsageCounter.ts
+++ b/src/middlewares/aiUsageCounter.ts
@@ -1,0 +1,42 @@
+import type { Response, NextFunction } from 'express';
+import AuthenticatedRequest from '@/types/authenticatedRequest';
+import aiRateLimiter from './aiRateLimiter';
+import type AiRateLimiter from '@/types/aiRateLimiter';
+import { logger } from '@/config/logger';
+
+const typedAiRateLimiter = aiRateLimiter as unknown as AiRateLimiter;
+
+const incrementAiLimitOnSuccess = (req: AuthenticatedRequest, res: Response, next: NextFunction): void => {
+
+    res.on('finish', async (): Promise<void> => {
+
+        if (res.statusCode >= 200 && res.statusCode <= 300) {
+            
+            try {
+                
+                typedAiRateLimiter.store.increment(typedAiRateLimiter.keyGenerator(req, res));
+
+            } catch (err: unknown) {
+
+                logger.error({
+
+                    message: 'Failed to increment AI limit',
+                    error: err instanceof Error ? err : String(err),
+                    stack: err instanceof Error ? err.stack : undefined,
+                    url: req.originalUrl,
+                    method: req.method,
+                    status: res.statusCode
+
+                });
+                
+            }
+
+        }
+
+    });
+
+    next();
+
+};
+
+export default incrementAiLimitOnSuccess;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, RequestHandler } from 'express';
 import authRouter from './auth';
 import aiRouter from './ai';
 import userRouter from './me';
@@ -6,11 +6,12 @@ import projectRouter from './projects/index';
 import isAuthenticated from '../middlewares/isAuthenticated';
 import aiRateLimiter from '@/middlewares/aiRateLimiter';
 import timerRouter from './projects/timer';
+import incrementAiLimitOnSuccess from '@/middlewares/aiUsageCounter';
 
 const router = Router();
 
 router.use('/v1/auth', authRouter);
-router.use('/v1/ai', isAuthenticated, aiRateLimiter, aiRouter);
+router.use('/v1/ai', isAuthenticated, aiRateLimiter, incrementAiLimitOnSuccess as RequestHandler, aiRouter);
 router.use('/v1/me', isAuthenticated, userRouter);
 router.use('/v1/projects', isAuthenticated, projectRouter);
 router.use('/v1/timer', timerRouter);

--- a/src/services/memberProductivityService.ts
+++ b/src/services/memberProductivityService.ts
@@ -1,6 +1,6 @@
 import { models } from '../models';
 import { AppError } from '@/types';
-import { Op, fn, col, literal } from 'sequelize';
+import { fn, col, literal } from 'sequelize';
 import {
   MemberProductivityData,
   MemberProductivityFilters,

--- a/src/services/summaryService.ts
+++ b/src/services/summaryService.ts
@@ -1,5 +1,4 @@
 import { models } from '../models';
-import { AppError } from '../types/customError';
 import { 
 	SprintProgressResponse, 
 	PriorityBreakdownResponse, 

--- a/src/types/aiRateLimiter.ts
+++ b/src/types/aiRateLimiter.ts
@@ -1,0 +1,17 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+import { type Store } from "express-rate-limit"
+
+interface AiRateLimiter extends RequestHandler {
+
+    windowMs: number;
+	limit: number;
+    keyGenerator: (req: Request, res: Response) => string;
+	store: Store;
+	skip: () => boolean;
+	handler: (req: Request, res: Response, next: NextFunction) => void;
+
+    (req: Request, res: Response, next: NextFunction): void;
+
+}
+
+export default AiRateLimiter;

--- a/src/types/aiRateLimiter.ts
+++ b/src/types/aiRateLimiter.ts
@@ -5,9 +5,10 @@ interface AiRateLimiter extends RequestHandler {
 
     windowMs: number;
 	limit: number;
+	skip: () => boolean;
+	skipFailedRequests: boolean;
     keyGenerator: (req: Request, res: Response) => string;
 	store: Store;
-	skip: () => boolean;
 	handler: (req: Request, res: Response, next: NextFunction) => void;
 
     (req: Request, res: Response, next: NextFunction): void;


### PR DESCRIPTION
So basically what I did here is:
     I added a new middleware for AI related routes. It increments the count in the Redis store only when the req is 2xx and provides extra logging for errors.
     But, there is a built-in property called skipFailedRequests: true, which increments the count in the Redis store when the req is both 2xx and 3xx.
     

So, currently both are being used a new custom middleware and a built-in property. Our current logic only allows 2xx requests and provides extra logging in case of errors.
